### PR TITLE
Adding AWAY to Status model.

### DIFF
--- a/bitsd/persistence/models.py
+++ b/bitsd/persistence/models.py
@@ -66,9 +66,10 @@ class Status(Base):
 
     OPEN = 'open'
     CLOSED = 'closed'
+    AWAY = 'away'
 
     timestamp = Column(DateTime, primary_key=True, default=datetime.now)
-    value = Column(Enum(OPEN, CLOSED), nullable=False)
+    value = Column(Enum(OPEN, CLOSED, AWAY), nullable=False)
     modified_by = Column(Enum('BITS', 'web'), nullable=False)
 
     def __init__(self, value, modified_by):


### PR DESCRIPTION
Here is the foundation of a long wanted feature: the "away" status when the keys are not at the reception desk, but POuL is closed. For instance, this happens while people go away for half an hour to have lunch.
