### PR TITLE
Server code for configuring JS logging verbosity

### DIFF
--- a/bitsd/server/assets/index_main.js
+++ b/bitsd/server/assets/index_main.js
@@ -5,7 +5,7 @@ main(function (require) {
         browserHandler = require("browser_handler"),
         WebSocket = require("websocket").WebSocket,
         location = require("location"),
-        query = require("document").querySelector,
+        query = require("peppy").query,
         debug = require("debug"),
 
         ws = new WebSocket("ws://" + location.hostname + ":" + location.port + "/ws"),

--- a/bitsd/server/templates/base.html
+++ b/bitsd/server/templates/base.html
@@ -15,6 +15,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head>
   <title>B.I.T.S. | {% block title%}Test title!{% end %}</title>
+  {% module DebugMode() %}
 </head>
 <body>
   <header class="logo" onclick="location.href = '/'">

--- a/bitsd/server/uimodules.py
+++ b/bitsd/server/uimodules.py
@@ -11,6 +11,14 @@ Assorted Tornado UI widgets and mixins.
 """
 
 import tornado.web
+from tornado.options import options
+
+
+class DebugMode(tornado.web.UIModule):
+    def render(self):
+        return '<meta name="mode" content="{mode}"/>'.format(
+            mode='debug' if options.developer_mode else 'production'
+        )
 
 
 class BasePage(tornado.web.UIModule):
@@ -42,12 +50,12 @@ class DynamicPage(tornado.web.UIModule):
             '/static/lib/g.line-min.js?v=1',
             '/static/lib/json2.js?v=2',
             '/static/lib/peppy.js?v=2',
-            '/static/debug.js?v=1',
+            '/static/debug.js?v=2',
             '/static/html5.js?v=1',
             '/static/browser_handler.js?v=1',
             '/static/handler.js?v=2',
             '/static/websocket.js?v=1',
-            '/static/index_main.js?v=3',
+            '/static/index_main.js?v=4',
         )
 
     def render(self):


### PR DESCRIPTION
I have implemented the server code setting a `meta` header which is used by Javascript to set log verbosity. I have also incremented JS version number in assets (for forcing browser caches flush) and fixed a change by Gattuso which broke the client side code (see upstream issue #5) in `index_main.js`: I'm not sure that it will work as expected, but at least it does not break clients...
