### PR TITLE
Making JSON dict-wrap default in models.

### DIFF
--- a/bitsd/listener/hooks.py
+++ b/bitsd/listener/hooks.py
@@ -51,7 +51,7 @@ def handle_temperature_command(sensorid, value):
 
     with session_scope() as session:
         temp = query.log_temperature(session, value, sensorid, 'BITS')
-        broadcast(temp.jsondict(wrap=True))  # wrapped in a dict
+        broadcast(temp.jsondict())
 
 
 def handle_status_command(status):
@@ -73,7 +73,7 @@ def handle_status_command(status):
         curstatus = query.get_current_status(session)
         if curstatus is None or curstatus.value != textstatus:
             status = query.log_status(session, textstatus, 'BITS')
-            broadcast(status.jsondict(wrap=True))  # wrapped in a dict
+            broadcast(status.jsondict())
         else:
             LOG.error('BITS already open/closed! Ignoring.')
 
@@ -120,7 +120,7 @@ def handle_message_command(message):
             message = query.log_message(session, user, text)
             # We need a flush here so that the associated User is referenced
             session.flush()
-            broadcast(message.jsondict(wrap=True))
+            broadcast(message.jsondict())
             FONERA.message(text)
 
 

--- a/bitsd/persistence/models.py
+++ b/bitsd/persistence/models.py
@@ -47,7 +47,7 @@ class TemperatureSample(Base):
     def __str__(self):
         return 'Temperature {.value}°C'.format(self)
 
-    def jsondict(self, wrap=False):
+    def jsondict(self, wrap=True):
         """Return a JSON-serializable dictionary representing the object"""
         data = {
             "timestamp": self.timestamp.isoformat(' '),
@@ -80,7 +80,7 @@ class Status(Base):
     def __str__(self):
         return 'Status {.value}'.format(self)
 
-    def jsondict(self, wrap=False):
+    def jsondict(self, wrap=True):
         """Return a JSON-serializable dictionary representing the object"""
         data = {
             "timestamp": self.timestamp.isoformat(' '),
@@ -108,7 +108,7 @@ class Message(Base):
         self.userid = userid
         self.message = message
 
-    def jsondict(self, wrap=False):
+    def jsondict(self, wrap=True):
         """Return a JSON-serializable dictionary representing the object"""
         data = {
             'user': self.author.name,
@@ -134,13 +134,14 @@ class Page(Base):
     def __str__(self):
         return 'Page: {.title}'.format(self)
 
-    def jsondict(self):
+    def jsondict(self, wrap=True):
         """Return a JSON-serializable dictionary representing the object"""
-        return {
+        data = {
             "title": self.title,
             "body": self.body,
             "slug": self.slug
         }
+        return {"page": data} if wrap else data
 
     @staticmethod
     def slugify(title):

--- a/bitsd/persistence/query.py
+++ b/bitsd/persistence/query.py
@@ -79,13 +79,13 @@ def get_latest_data(session):
     latest_temp_samples = get_latest_temperature_samples(session)
     latest_message = get_current_message(session)
 
-    json_or_none = lambda data: data.jsondict() if data is not None else ""
+    json_or_none = lambda data: data.jsondict(wrap=False) if data is not None else ""
     return {
         "status": json_or_none(status),
         "tempint": json_or_none(temp),
         "version": options.jsonver,
         "msg": json_or_none(latest_message),
-        "tempinthist": [sample.jsondict() for sample in latest_temp_samples]
+        "tempinthist": [sample.jsondict(wrap=False) for sample in latest_temp_samples]
     }
 
 

--- a/bitsd/server/handlers.py
+++ b/bitsd/server/handlers.py
@@ -243,7 +243,7 @@ class AdminPageHandler(BaseHandler):
                      ' from web interface.')
             try:
                 status = query.log_status(session, textstatus, 'web')
-                broadcast(status.jsondict(wrap=True))  # wrapped in a dict
+                broadcast(status.jsondict())
                 message = "Modifica dello stato effettuata."
             except query.SameTimestampException:
                 LOG.error("Status changed too quickly, not logged.")


### PR DESCRIPTION
Each model has a `.jsondict()` method for returning a JSON-serializable dictionary. 90% of times you will want such data wrapped in a dictionary, because the client message loop expects this and because it's secured against JS exploits. Hence, I have made `wrap=True` the default behaviour.
