### PR TITLE
bits requires python2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,11 @@ pyclean:
 	find bitsd -regex ".*\.pyc" -delete
 
 source:
-	python setup.py sdist
+	python2 setup.py sdist
 
 rpm:
-	python setup.py bdist_rpm
+	python2 setup.py bdist_rpm
 
 virtualenv:
-	virtualenv env
+	virtualenv2 env
 	. env/bin/activate && pip install tornado sqlalchemy markdown futures pycares passlib recaptcha

--- a/bitsd.py
+++ b/bitsd.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 
 from bitsd.main import main
 

--- a/bootstrap.py
+++ b/bootstrap.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 #
 # Copyright (C) 2013 Stefano Sanfilippo
 # Copyright (C) 2013 BITS development team

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 #
 # bitsd documentation build configuration file, created by

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#! /usr/bin/python
+#! /usr/bin/env python2
 #
 # Copyright (C) 2013 Stefano Sanfilippo
 # Copyright (C) 2013 BITS development team

--- a/usermanage.py
+++ b/usermanage.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 #
 # Copyright (C) 2013 Stefano Sanfilippo
 # Copyright (C) 2013 BITS development team


### PR DESCRIPTION
Solves bug with distributions that defaults to python3 instead of python2
